### PR TITLE
Thermal Foundation - Fixed missing dye textures and 4 gear textures.

### DIFF
--- a/Thermal_Foundation/assets/thermalfoundation/blockstates/dye.json
+++ b/Thermal_Foundation/assets/thermalfoundation/blockstates/dye.json
@@ -1,0 +1,94 @@
+{
+	"forge_marker": 1,
+	"defaults": {
+		"model": "builtin/generated",
+		"textures": {
+			"layer0": "blocks/dirt"
+		},
+		"transform": "forge:default-item"
+	},
+	"variants": {
+		"type": {
+			"dyeblack": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyered": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyegreen": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyebrown": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyeblue": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyepurple": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyecyan": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyelightgray": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyegray": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyepink": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyelime": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyeyellow": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyelightblue": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyemagenta": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyeorange": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			},
+			"dyewhite": {
+				"textures": {
+					"layer0": "soartex_base:items/dye/dye_powder"
+				}
+			}
+		}
+	}
+}

--- a/Thermal_Foundation/assets/thermalfoundation/blockstates/material.json
+++ b/Thermal_Foundation/assets/thermalfoundation/blockstates/material.json
@@ -319,6 +319,16 @@
           "layer0": "soartex_base:items/nugget/enderium"
         }
       },
+	  "gearwood": {
+        "textures": {
+          "layer0": "soartex_base:items/gear/wood"
+        }
+      },
+	  "gearstone": {
+        "textures": {
+          "layer0": "soartex_base:items/gear/stone"
+        }
+      },
       "geariron": {
         "textures": {
           "layer0": "soartex_base:items/gear/iron"

--- a/Thermal_Foundation/assets/thermalfoundation/blockstates/material.json
+++ b/Thermal_Foundation/assets/thermalfoundation/blockstates/material.json
@@ -414,6 +414,16 @@
           "layer0": "soartex_base:items/gear/enderium"
         }
       },
+	  "geardiamond": {
+        "textures": {
+          "layer0": "soartex_base:items/gear/diamond"
+        }
+      },
+	  "gearemerald": {
+        "textures": {
+          "layer0": "soartex_base:items/gear/emerald"
+        }
+      },
       "plateiron": {
         "textures": {
           "layer0": "soartex_base:items/plate/iron"


### PR DESCRIPTION
fixed the dyes not having textures, now they pull from soartex_base.

fixed missing diamond and emerald gears, although I cannot add those as soartex-base isn't hosted here.

Diamond Gear can be pulled from Buildcraft 7 textures. Emerald gear I can send via email or dropbox or something.